### PR TITLE
feat: send product flow to approve payment mutation

### DIFF
--- a/src/googlepay.js
+++ b/src/googlepay.js
@@ -1,6 +1,11 @@
 /* @flow */
 
-import { getClientID, getLogger, getMerchantID, getBuyerCountry } from "@paypal/sdk-client/src";
+import {
+  getClientID,
+  getLogger,
+  getMerchantID,
+  getBuyerCountry,
+} from "@paypal/sdk-client/src";
 import { FPTI_KEY } from "@paypal/sdk-constants/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import { getThreeDomainSecureComponent } from "@paypal/common-components/src/three-domain-secure";
@@ -129,7 +134,7 @@ export function confirmOrder({
         orderID: orderId,
         shippingAddress,
         email,
-        productFlow: 'CUSTOM_DIGITAL_WALLET',
+        productFlow: "CUSTOM_DIGITAL_WALLET",
       },
     }),
   })

--- a/src/googlepay.js
+++ b/src/googlepay.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getClientID, getLogger, getMerchantID } from "@paypal/sdk-client/src";
+import { getClientID, getLogger, getMerchantID, getBuyerCountry } from "@paypal/sdk-client/src";
 import { FPTI_KEY } from "@paypal/sdk-constants/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import { getThreeDomainSecureComponent } from "@paypal/common-components/src/three-domain-secure";
@@ -40,6 +40,7 @@ export function googlePayConfig(): Promise<
         clientId: getClientID(),
         merchantId: getMerchantID(),
         merchantOrigin: getMerchantDomain(),
+        buyerCountry: getBuyerCountry(),
       },
     }),
   })
@@ -111,6 +112,7 @@ export function confirmOrder({
                       $clientID : String!
                       $shippingAddress: GooglePayPaymentContact
                       $email: String
+                      $productFlow: String
                     ) {
                       approveGooglePayPayment(
                         paymentMethodData: $paymentMethodData
@@ -118,6 +120,7 @@ export function confirmOrder({
                         clientID: $clientID
                         shippingAddress: $shippingAddress
                         email: $email
+                        productFlow: $productFlow
                       )
                     }`,
       variables: {
@@ -126,6 +129,7 @@ export function confirmOrder({
         orderID: orderId,
         shippingAddress,
         email,
+        productFlow: 'CUSTOM_DIGITAL_WALLET',
       },
     }),
   })

--- a/src/util.js
+++ b/src/util.js
@@ -82,11 +82,13 @@ export function getConfigQuery(): string {
         $clientId: String!
         $merchantId: [String]!
         $merchantOrigin: String!
+        $buyerCountry: CountryCodes
     ) {
         googlePayConfig(
         clientId: $clientId
         merchantId: $merchantId
         merchantOrigin: $merchantOrigin
+        buyerCountry: $buyerCountry
         ){
         isEligible
         apiVersion


### PR DESCRIPTION
### Description
This adds a new optional param in the Approve Googlepay graphql mutation in order to specify that the googlepay flow is coming from the googlepay custom component rather than Smart Payment Buttons.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
GooglePay flow via SDK currently only comes from the custom googlepay component. In the future, there will more than one integration (SPB). We will need to differentiate between SPB and Custom Components flows.
https://paypal.atlassian.net/browse/DTALTPAY-1623

### Reproduction Steps (if applicable)
Merchant specifies components=googlepay in SDK script to use the paypal-googlepay-component custom component.
Selecting the googlepay payment method will start the flow. Buyer approval leads to the approve googlepay payment mutation call.

### Screenshots (if applicable)

### Dependent Changes (if applicable)
Changes to xobuyer mutation are for an optional variable, so this is a non-breaking change.