### PR TITLE
fix: update Node.js version in CI workflows to match package.json requirements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         # sets up the .npmrc file to publish to npm
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
       - name: 📥 Download deps

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@paypal/googlepay-components",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "A Web Component for GooglePay Integration",
   "main": "index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
+    "clean": "rimraf dist",
     "flow-typed": "flow-typed install",
     "flow": "flow",
     "flow:build": "flow gen-flow-files ./src/index.js --out-dir ./dist/module",


### PR DESCRIPTION
- Update publish workflow to use Node.js 18 instead of 16
- Add missing clean script for release process
- Ensures compatibility with lint-staged and other dependencies that require Node 18+